### PR TITLE
Updated the drug info UI

### DIFF
--- a/EXPOFILES/drugInfoGui.py
+++ b/EXPOFILES/drugInfoGui.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 import tkinter as tk
 from typing import TYPE_CHECKING
 
+import individualDrug
+import functools
+
+from database.queries.query import medicationsQuery
+
 from constants.window import *
 import utils.interfaceHelpers as UI
-
-import drugsCom as drugsCom
 
 if TYPE_CHECKING:
     from UIController import UIController
@@ -15,62 +18,49 @@ if TYPE_CHECKING:
 # The unknown value and create a button for each one. Then, when a particular button
 # is pressed, perform a web scrape for that medication
 
+def goToCommand(UIController, medName):
+	print("Click")
+	individualDrug.individualDrug(UIController, medName=medName)
+	pass
+
 def loadingDrugGui(UIController: UIController):
 
 	# This is the section of code which creates the a label
-	reports_label = tk.Label(UIController.canvas, text='Drug Info', bg='#F0F8FF', font=('arial', 40, 'normal'))
+	d_info_label = tk.Label(UIController.canvas, text='Drug Info', bg='#F0F8FF', font=('arial', 40, 'normal'))
 
-	# Creating a photoimage object to use image
-	times_asked = tk.PhotoImage(file="EXPOFILES/assets/timesAsked.png")
-	label = tk.Label(image=times_asked)
-	label.image = times_asked
-
-	rosuvastatin_btn = UI.NewHomeBtn(master=UIController.canvas, text='Rosuvastatin', command=drugsCom.rosuvastatin)
-	tamsulosin_btn = UI.NewHomeBtn(master=UIController.canvas, text='Tamsulosin', command=drugsCom.tamsulosin)
-	go_back_btn = UI.NewHomeBtn(master=UIController.canvas, text='Go Back', command=UIController.goToHome)
-	# click_me_btn = tk.Button(UIController.canvas, image=report_image, command=clickFunc)
+	go_back_btn = UI.NewExitBtn(master=UIController.canvas, text='Go Back', command=UIController.goToHome)
 
 	UIController.canvasIds["DrugInfo"] = []
-	UIController.canvasIds["DrugInfo"].append(UIController.canvas.create_window(WINDOW_WIDTH / 2, WINDOW_HEIGHT / 20, window=reports_label, anchor=tk.N))
-	UIController.canvasIds["DrugInfo"].append(UIController.canvas.create_window(WINDOW_WIDTH_PADDING, WINDOW_HEIGHT_PADDING, window=rosuvastatin_btn, anchor=tk.SE))
-	UIController.canvasIds["DrugInfo"].append(UIController.canvas.create_window(WINDOW_WIDTH_PADDING / 2, WINDOW_HEIGHT_PADDING, window=tamsulosin_btn, anchor=tk.S))
+	medications = medicationsQuery(UIController.conn)
+	for index, med in enumerate(medications):
+		med_button = UI.NewMedBtn(
+			master=UIController.canvas, 
+			text=f'{med.medName}', 
+			command= functools.partial(goToCommand, UIController, med.medName)
+		)
+		yPos = (((index + 1) * 150) + (WINDOW_HEIGHT / 2))
+		xPos = WINDOW_WIDTH / 1.35
+		print(f'{index} {xPos}, {yPos}')
+		med_button.grid(row=index, column=0)
+		UIController.canvasIds["DrugInfo"].append(
+			UIController.canvas.create_window(
+				int(xPos),int(yPos), 
+				window=med_button
+			)
+		)
+	
+	eva_face = UI.evaFace(file="EXPOFILES/assets/evaFaceRedLarge.png")
+	eva_text = UI.evaText(
+        canvas=UIController.canvas, 
+        text="Select a \nmed for information"
+	)
+	UIController.canvasIds["DrugInfo"].append(UIController.canvas.create_window(
+        275, WINDOW_HEIGHT / 5, window=eva_text
+    ))
+	UIController.canvasIds["DrugInfo"].append(UIController.canvas.create_window(
+        275, WINDOW_HEIGHT / 2, window=eva_face
+    ))
+	UIController.canvasIds["DrugInfo"].append(UIController.canvas.create_window(WINDOW_WIDTH / 2, WINDOW_HEIGHT / 20, window=d_info_label, anchor=tk.N))
+	
 	UIController.canvasIds["DrugInfo"].append(UIController.canvas.create_window(WINDOW_PADDING, WINDOW_HEIGHT_PADDING, window=go_back_btn, anchor=tk.SW))
-	# UIController.canvasIds["Report"].append(UIController.canvas.create_window(WINDOW_PADDING / 2, WINDOW_HEIGHT_PADDING / 2, window=click_me_btn))
-	UIController.canvasIds["DrugInfo"].append(UIController.canvas.create_window(WINDOW_WIDTH / 2, WINDOW_HEIGHT / 2, window=label, anchor=tk.CENTER))
-		
-	# global root
-	# root = Toplevel()
-
-	# bg = PhotoImage(file="EXPOFILES/assets/view.png")
-
-	# root.geometry('1280x800')
-
-	# # Adding widgets to the root window
-
-	# # This is the section of code which creates the a label
-	# Label(root, text='Click Me !', image=bg).place(x=0, y=0)
-
-
-	# # Creating a photoimage object to use image
-	# imPath = "EXPOFILES/assets/timesAsked.png"
-	# photo = PhotoImage(file=imPath)
-
-	# print("oeo")
-
-	# Button(root, text='Rosuvastatin', bg='#FFB90F', font=('Roboto', 40, 'normal'), command=rosuvastatin).place(x=200, y=200)
-
-	# Button(root, text='Tamsulosin', bg='#E1912A', font=('Roboto', 40, 'normal'), command=tamsulosin).place(x=700, y=200)
-
-	# Button(root, text='Exit', bg='#9A32CD', font=('Roboto', 40, 'normal'), command=btnClickFunction).place(x=1100, y=640)
-
-
-	# if confir != 4:
-	# 	return confir
-	# print(confir)
-	# print("imhere")
-
-	# root.mainloop()
-
-
-# path = "C:\EVA\pillbottles\pillbottle1\image1.png"
-# loadingGui(path)
+	

--- a/EXPOFILES/drugInfoGui.py
+++ b/EXPOFILES/drugInfoGui.py
@@ -13,10 +13,6 @@ import utils.interfaceHelpers as UI
 if TYPE_CHECKING:
     from UIController import UIController
 
-# TODO: Make the buttons dynamic to the data in the database. This should be 
-# done by using a query to the database for all names in the database that aren't
-# The unknown value and create a button for each one. Then, when a particular button
-# is pressed, perform a web scrape for that medication
 
 def goToCommand(UIController, medName):
 	print("Click")

--- a/EXPOFILES/individualDrug.py
+++ b/EXPOFILES/individualDrug.py
@@ -33,16 +33,12 @@ def readSite(url, drugname):
                     print(dat.text)
                     return dat.text
                     infoCount = infoCount + 1
-        return soup
+                return "Could not find the medicine on Drugs.com"
     else:
-        print('couldnt open')
+        return "Could not open Drugs.com to get medicine information"
 
 def individualDrug(UIController: UIController, medName: str) -> None:
 
-    def goBack():
-        UIController.clearUI("DrugInfo")
-        print(UIController.canvasIds)
-        UIController.goToDrugInfo()
 
     UIController.clearUI("DrugInfo")
 

--- a/EXPOFILES/individualDrug.py
+++ b/EXPOFILES/individualDrug.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+import tkinter as tk
+from typing import TYPE_CHECKING
+
+import requests
+from bs4 import BeautifulSoup
+import utils.interfaceHelpers as UI
+from constants.window import *
+
+whatis = "What is"
+warningString = "Warning"
+seString = 'side effects'
+iTakeString = 'take'
+
+if TYPE_CHECKING:
+    from UIController import UIController
+
+def readSite(url, drugname):
+    resp = requests.get(url)
+    infoCount = 0
+
+    if resp.status_code == 200:
+
+        soup = BeautifulSoup(resp.text, 'lxml')
+
+        for data in soup.find_all('h2'):
+            if whatis in data.text:
+                for dat in data.find_all_next(['p', 'h2']):
+                    if infoCount > 0:
+                        break
+                    if dat.name == 'h2':
+                        break
+                    print(dat.text)
+                    return dat.text
+                    infoCount = infoCount + 1
+        return soup
+    else:
+        print('couldnt open')
+
+def individualDrug(UIController: UIController, medName: str) -> None:
+
+    def goBack():
+        UIController.clearUI("DrugInfo")
+        print(UIController.canvasIds)
+        UIController.goToDrugInfo()
+
+    UIController.clearUI("DrugInfo")
+
+    url = f'https://www.drugs.com/{medName}.html'
+    siteText = readSite(url, medName)
+    
+    info_label = tk.Label(UIController.canvas, text=f'{medName}', bg='#F0F8FF', font=('arial', 40, 'normal'))
+    info_text = tk.Label(UIController.canvas, text=f'{siteText}', bg='#F0F8FF', font=('arial', 20, 'normal'), wraplength=1000)
+    go_back_btn = UI.NewExitBtn(master=UIController.canvas, text='Go Back', command=UIController.goToDrugInfo)
+
+    UIController.canvasIds["DrugInfo"].append(UIController.canvas.create_window(WINDOW_WIDTH / 2, WINDOW_HEIGHT / 20, window=info_label, anchor=tk.N))
+    UIController.canvasIds["DrugInfo"].append(UIController.canvas.create_window(WINDOW_WIDTH / 2, WINDOW_HEIGHT / 2, window=info_text, anchor=tk.CENTER))
+    UIController.canvasIds["DrugInfo"].append(UIController.canvas.create_window(WINDOW_PADDING, WINDOW_HEIGHT_PADDING, window=go_back_btn, anchor=tk.SW))


### PR DESCRIPTION
I've updated the drug info UI to be in one window. Medications are queried, then a button is made for all of them. By clicking the button, you move to the individual drug page that contains the drug name, its description from drugs.com, and a button to go back to the drugs info main page. Please let me know if there are any further formatting changes I should make before we merge this.